### PR TITLE
editMode now not always set

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -176,7 +176,8 @@ export default class MyPlugin extends Plugin {
     get editor(): Editor {
         const view = this.app.workspace.activeLeaf.view;
         try {
-            if (view.editMode.type == "source") {
+            if (('editMode' in view && view.editMode.type == "source") ||
+	        ('editor' in view)) {
                 return view.editor;
             }
 	    else {


### PR DESCRIPTION
You can now be in edit mode and not have 'editMode' set, this may have something to do with live preview?

This is still not 100% complete, but it at least no longer errors out.

The file is currently not being written into the vault location.